### PR TITLE
Update deprecated sinatra-content-for gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 # Sinatra microframework
-gem "sinatra", "~> 1.2.6", require: "sinatra/base"
+gem "sinatra", "~> 1.3.0", require: "sinatra/base"
 
 # JS Compression
 gem "jsmin", "~> 1.0.1"
@@ -12,7 +12,7 @@ gem "sass", "~> 3.1.1"
 gem "less"
 
 # Sinatra extensions
-gem "sinatra-content-for", require: "sinatra/content_for"
+gem "sinatra-contrib", require: "sinatra/content_for"
 gem "sinatra-support", "~> 1.2.0", require: "sinatra/support"
 gem "sinatra-assetpack", git: "git://github.com/rstacruz/sinatra-assetpack.git", require: "sinatra/assetpack"
 gem "sinatra-backbone", git: "git://github.com/rstacruz/sinatra-backbone.git", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: git://github.com/rstacruz/sinatra-assetpack.git
-  revision: 3d677aa29eca349e98eac358b4c53cd9797a5a97
+  revision: 1aa835c164f53ffda2a8c6f589a04c4eb92859cf
   specs:
-    sinatra-assetpack (0.0.8)
+    sinatra-assetpack (0.0.11)
       jsmin
       rack-test
       sinatra
@@ -18,6 +18,7 @@ GIT
 GEM
   remote: http://rubygems.org/
   specs:
+    backports (2.5.1)
     capybara (1.0.1)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -37,6 +38,7 @@ GEM
       fssm (>= 0.2.7)
       sass (~> 3.1)
     contest (0.1.3)
+    eventmachine (0.12.10)
     execjs (1.2.4)
       multi_json (~> 1.0)
     ffi (1.0.9)
@@ -53,7 +55,9 @@ GEM
     multi_json (1.0.3)
     nokogiri (1.5.0)
     pistol (0.0.2)
-    rack (1.3.2)
+    rack (1.4.1)
+    rack-protection (1.2.0)
+      rack
     rack-test (0.6.1)
       rack (>= 1.0)
     rtopia (0.2.3)
@@ -65,11 +69,17 @@ GEM
       json_pure
       rubyzip
     sequel (3.27.0)
-    sinatra (1.2.6)
-      rack (~> 1.1)
-      tilt (< 2.0, >= 1.2.2)
-    sinatra-content-for (0.2)
-      sinatra
+    sinatra (1.3.2)
+      rack (~> 1.3, >= 1.3.6)
+      rack-protection (~> 1.2)
+      tilt (~> 1.3, >= 1.3.3)
+    sinatra-contrib (1.3.1)
+      backports (>= 2.0)
+      eventmachine
+      rack-protection
+      rack-test
+      sinatra (~> 1.3.0)
+      tilt (~> 1.3)
     sinatra-sequel (0.9.0)
       sequel (>= 3.2.0)
       sinatra (>= 0.9.4)
@@ -99,10 +109,10 @@ DEPENDENCIES
   rtopia (~> 0.2.3)
   sass (~> 3.1.1)
   sequel
-  sinatra (~> 1.2.6)
+  sinatra (~> 1.3.0)
   sinatra-assetpack!
   sinatra-backbone!
-  sinatra-content-for
+  sinatra-contrib
   sinatra-sequel
   sinatra-support (~> 1.2.0)
   sqlite3


### PR DESCRIPTION
The sinatra-content-for gem has been rolled into the sintra-contrib
gem.

This fixes deploying to heroku.
